### PR TITLE
fix: Makes作品が公開ページに反映されないバグ修正 + 管理画面の保存フローUX改善

### DIFF
--- a/app/admin/makes/EditMakesClient.js
+++ b/app/admin/makes/EditMakesClient.js
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { savePageContent } from '../../actions';
 import TechStackInput from '../../../components/admin/TechStackInput';
@@ -14,6 +14,18 @@ export default function EditMakesClient({ initialData }) {
     const [loading, setLoading] = useState(false);
     const [message, setMessage] = useState(null);
     const [editingId, setEditingId] = useState(null); // ID of item being edited
+    const [isDirty, setIsDirty] = useState(false); // 未保存の変更があるか
+
+    // 未保存のままページを閉じる/リロードしようとしたら警告
+    useEffect(() => {
+        if (!isDirty) return;
+        const handleBeforeUnload = (e) => {
+            e.preventDefault();
+            e.returnValue = '';
+        };
+        window.addEventListener('beforeunload', handleBeforeUnload);
+        return () => window.removeEventListener('beforeunload', handleBeforeUnload);
+    }, [isDirty]);
 
     // Form state (used for both Add and Edit)
     const [formState, setFormState] = useState({
@@ -34,7 +46,8 @@ export default function EditMakesClient({ initialData }) {
             const result = await savePageContent('makes', { title, items });
 
             if (result.success) {
-                setMessage({ type: 'success', text: 'Saved successfully!' });
+                setIsDirty(false);
+                setMessage({ type: 'success', text: '保存しました。公開ページに反映されています。' });
                 router.refresh();
                 setTimeout(() => setMessage(null), 3000);
             } else {
@@ -61,14 +74,15 @@ export default function EditMakesClient({ initialData }) {
             setItems(items.map(item =>
                 item.id === editingId ? { ...formState, id: editingId } : item
             ));
-            setMessage({ type: 'success', text: 'Item updated. Remember to Save All Changes.' });
+            setMessage({ type: 'warning', text: 'リスト上で更新しました（まだ保存されていません）。右下の「Save All Changes」を押すと反映されます。' });
         } else {
             // Add new item
             const id = crypto.randomUUID();
             const itemToAdd = { ...formState, id };
             setItems([itemToAdd, ...items]);
-            setMessage({ type: 'success', text: 'New item added. Remember to Save All Changes.' });
+            setMessage({ type: 'warning', text: 'リストに追加しました（まだ保存されていません）。右下の「Save All Changes」を押すと公開されます。' });
         }
+        setIsDirty(true);
 
         // Reset form
         resetForm();
@@ -102,13 +116,22 @@ export default function EditMakesClient({ initialData }) {
     };
 
     const handleDeleteItem = (id) => {
-        if (confirm('Are you sure you want to delete this item?')) {
+        if (confirm('この項目を削除しますか？（「Save All Changes」を押すまで確定されません）')) {
             setItems(items.filter(item => item.id !== id));
+            setIsDirty(true);
+            setMessage({ type: 'warning', text: 'リストから削除しました（まだ保存されていません）。右下の「Save All Changes」を押すと反映されます。' });
             // If deleting the currently edited item, reset form
             if (editingId === id) {
                 resetForm();
             }
         }
+    };
+
+    const handleBackToDashboard = () => {
+        if (isDirty && !confirm('未保存の変更があります。保存せずにダッシュボードに戻りますか？')) {
+            return;
+        }
+        router.push('/admin/dashboard');
     };
 
     const handleImageUpload = async (e) => {
@@ -146,7 +169,7 @@ export default function EditMakesClient({ initialData }) {
         <div className={styles.container}>
             <div className={styles.header}>
                 <h1 className={styles.pageTitle}>Manage Makes</h1>
-                <button onClick={() => router.push('/admin/dashboard')} className={styles.backButton}>
+                <button onClick={handleBackToDashboard} className={styles.backButton}>
                     ← Dashboard
                 </button>
             </div>
@@ -228,6 +251,17 @@ export default function EditMakesClient({ initialData }) {
                         </div>
                     </div>
 
+                    <div className={styles.formGroup}>
+                        <label className={styles.publishToggle}>
+                            <input
+                                type="checkbox"
+                                checked={formState.isPublished}
+                                onChange={(e) => setFormState({ ...formState, isPublished: e.target.checked })}
+                            />
+                            公開する（オフにすると下書きとして保存され、公開ページには表示されません）
+                        </label>
+                    </div>
+
                     <div className={styles.formActions}>
                         {editingId && (
                             <button
@@ -258,6 +292,9 @@ export default function EditMakesClient({ initialData }) {
                                 <div className={styles.itemHeader}>
                                     <span style={{ fontWeight: 'bold' }}>
                                         {item.title}
+                                        {item.isPublished === false && (
+                                            <span className={styles.draftBadge}>下書き</span>
+                                        )}
                                     </span>
                                     <div>
                                         <button
@@ -298,9 +335,12 @@ export default function EditMakesClient({ initialData }) {
             </div>
 
             <div className={styles.floatingSave}>
+                {isDirty && (
+                    <span className={styles.unsavedBadge}>● 未保存の変更があります</span>
+                )}
                 <button
                     onClick={handleSave}
-                    className={styles.saveButton}
+                    className={`${styles.saveButton} ${isDirty ? styles.saveButtonDirty : ''}`.trim()}
                     disabled={loading}
                 >
                     {loading ? 'Saving...' : 'Save All Changes'}

--- a/app/admin/makes/page.module.css
+++ b/app/admin/makes/page.module.css
@@ -247,6 +247,37 @@
     bottom: 2rem;
     right: 2rem;
     z-index: 100;
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 0.5rem;
+}
+
+.unsavedBadge {
+    background: #fff3cd;
+    color: #856404;
+    border: 1px solid #ffc107;
+    border-radius: 20px;
+    padding: 0.4rem 1rem;
+    font-size: 0.85rem;
+    font-weight: bold;
+    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}
+
+.saveButtonDirty {
+    animation: pulseSave 1.5s ease-in-out infinite;
+}
+
+@keyframes pulseSave {
+
+    0%,
+    100% {
+        box-shadow: 0 4px 15px rgba(255, 107, 26, 0.4);
+    }
+
+    50% {
+        box-shadow: 0 4px 25px rgba(255, 107, 26, 0.8);
+    }
 }
 
 .saveButton {
@@ -298,6 +329,42 @@
     background: rgba(220, 53, 69, 0.1);
     color: #dc3545;
     border: 1px solid #dc3545;
+}
+
+.warning {
+    background: rgba(255, 193, 7, 0.1);
+    color: #856404;
+    border: 1px solid #ffc107;
+}
+
+/* Publish Toggle & Draft Badge */
+.publishToggle {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+    cursor: pointer;
+    user-select: none;
+}
+
+.publishToggle input {
+    width: 1.1rem;
+    height: 1.1rem;
+    accent-color: var(--c-accent-1);
+    cursor: pointer;
+}
+
+.draftBadge {
+    display: inline-block;
+    margin-left: 0.5rem;
+    padding: 0.1rem 0.5rem;
+    font-size: 0.7rem;
+    font-weight: bold;
+    color: #856404;
+    background: #fff3cd;
+    border: 1px solid #ffc107;
+    border-radius: 4px;
+    vertical-align: middle;
 }
 
 @keyframes fadeIn {

--- a/app/makes/page.js
+++ b/app/makes/page.js
@@ -24,6 +24,8 @@ function getHostname(url) {
 export default async function MakesPage() {
     const content = await getContent();
     const makes = content.makes || { title: 'Makes', items: [] };
+    // 下書き(isPublished: false)は公開ページに表示しない
+    const publishedItems = (makes.items || []).filter((item) => item.isPublished !== false);
 
     return (
         <div className={styles.container}>
@@ -36,8 +38,8 @@ export default async function MakesPage() {
             </div>
 
             <div className={styles.grid}>
-                {makes.items && makes.items.length > 0 ? (
-                    makes.items.map((item) => (
+                {publishedItems.length > 0 ? (
+                    publishedItems.map((item) => (
                         <div key={item.id} className={styles.card}>
                             <div className={styles.thumbnailWrapper}>
                                 {item.thumbnail ? (

--- a/app/makes/page.js
+++ b/app/makes/page.js
@@ -4,10 +4,22 @@ import Link from 'next/link';
 import TechBadgeList from '../../components/TechBadgeList';
 import styles from './page.module.css';
 
+// ページキャッシュを無効化（常に最新データを取得）
+export const revalidate = 0;
+
 export const metadata = {
     title: 'Makes | Tobenaitsuru',
     description: 'My creations, products, and experiments.',
 };
+
+// 不正なURLでも throw させずホスト名を取り出す
+function getHostname(url) {
+    try {
+        return new URL(url).hostname;
+    } catch {
+        return url;
+    }
+}
 
 export default async function MakesPage() {
     const content = await getContent();
@@ -47,7 +59,7 @@ export default async function MakesPage() {
 
                                 {item.externalUrl && (
                                     <a href={item.externalUrl} target="_blank" rel="noopener noreferrer" className={styles.link}>
-                                        {new URL(item.externalUrl).hostname}
+                                        {getHostname(item.externalUrl)}
                                     </a>
                                 )}
                             </div>

--- a/app/page.js
+++ b/app/page.js
@@ -10,7 +10,8 @@ export const revalidate = 0;
 export default async function Home() {
     const content = await getContent();
     const { title, subtitle } = content?.home || { title: 'Tobenaitsuru', subtitle: 'Portfolio' };
-    const makesItems = content?.makes?.items || [];
+    // 下書き(isPublished: false)は公開ページに表示しない
+    const makesItems = (content?.makes?.items || []).filter((item) => item.isPublished !== false);
 
     return (
         <div className={styles.hero}>


### PR DESCRIPTION
## 概要
Closes #42, Closes #43, Closes #44, Closes #45

### バグ修正
- **#42**: `/makes` ページにだけ `export const revalidate = 0;` が抜けていたため、ビルド時の空の静的HTMLが配信され続け、管理画面で保存した作品が表示されなかった。他の公開ページと同様にキャッシュ無効化を追加。
  - 調査時にVercel KVを直接確認し、作品2件が正常に保存済みであること(=保存処理は正常で表示側の問題であること)を確認済み。
- **#43**: External URLが不正な形式だと `new URL()` が throw してページ全体がエラーになる問題を try/catch で防止。

### UX改善(管理画面 Makes)
- **#44**: 「+ Add Project」後のメッセージを警告色に変更し「まだ保存されていません」と明示。未保存の間は保存ボタンにバッジ+点滅表示。未保存のままの離脱(タブを閉じる/Dashboardに戻る)で確認ダイアログを表示。
- **#45**: 「公開する」チェックボックスを追加。下書き(isPublished: false)は `/makes` とトップページのカルーセルに表示しない。管理画面の一覧には「下書き」バッジを表示。

## テスト
- `npm run build` 成功。ルートテーブルで `/makes` が `○ (Static)` → `ƒ (Dynamic)` に変わったことを確認
- `npm run start` で実機確認: `/makes` に保存済み2作品(書籍のジャンル分類 / HP)が表示されることを確認
- トップページのカルーセル表示、about/skills/contact/works の200応答、未ログイン時の `/admin/makes` → `/admin/login` リダイレクトを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)