### PR TITLE
feat(top): 本をドラッグでめくれるようにし、スマホは紙束の表示に変更

### DIFF
--- a/components/MakesBook.js
+++ b/components/MakesBook.js
@@ -8,9 +8,21 @@ import styles from './MakesBook.module.css';
 const FLIP_MS = 950;
 // 開いた本のページの起き上がり角度（左右対称に手前へ開く）
 const TILT = 6;
+// めくる紙が本から浮き上がる高さ
+const LIFT = 30;
 const AUTOPLAY_MS = 6000;
 const STACK_LEAVES = 12; // 本全体の紙の厚み（枚数の見え方）
 const MIN_LEAVES = 2;
+const DRAG_START_PX = 6; // これ以上動かしたらめくり始める
+const FLICK_VELOCITY = 0.5; // px/ms：勢いよく払ったら最後までめくる
+const SINGLE_PAGE_MQ = '(max-width: 760px)';
+// 紙束モード（スマホ）：横へ抜く割合と、抜けきるまでの進捗
+const SLIDE_PHASE = 0.6;
+const SLIDE_X = 62; // %
+const SLIDE_LIFT = 60; // px（手前へ持ち上がる）
+const SLIDE_BACK = -40; // px（束の後ろへ回る）
+const SLIDE_ROTATE = 7; // deg
+const SLIDE_TRAVEL = 0.62; // ページ幅に対する指の移動距離
 
 /**
  * ページの外側に重なる紙束（厚み）を box-shadow の層で作る。
@@ -27,6 +39,78 @@ function leafStack(count, dir) {
     return layers.join(', ');
 }
 
+/** 見開き用：めくり具合（0 = 右ページの位置 / 1 = 左ページの位置）から紙の姿勢を作る */
+function bookTransform(progress) {
+    const angle = TILT + progress * (180 - TILT * 2);
+    const lift = Math.sin(progress * Math.PI) * LIFT;
+    return `rotateY(${-angle}deg) translateZ(${lift}px)`;
+}
+
+/**
+ * 紙束用：一番手前の紙を横へ抜いて、そのまま束の後ろへ回す。
+ * 0 = 束の一番手前 / SLIDE_PHASE = 横に抜けきったところ / 1 = 束の一番後ろ
+ */
+function stackParts(progress) {
+    const slide = Math.sin((Math.min(progress, SLIDE_PHASE) / SLIDE_PHASE) * (Math.PI / 2));
+    const settle = progress <= SLIDE_PHASE ? 0 : (progress - SLIDE_PHASE) / (1 - SLIDE_PHASE);
+    return {
+        x: -SLIDE_X * (slide - settle),
+        z: 1 + slide * SLIDE_LIFT + settle * (SLIDE_BACK - SLIDE_LIFT - 1),
+        tilt: -SLIDE_ROTATE * (slide - settle),
+    };
+}
+
+function stackTransform(progress) {
+    const { x, z, tilt } = stackParts(progress);
+    return `translateX(${x.toFixed(2)}%) translateZ(${z.toFixed(2)}px) rotate(${tilt.toFixed(2)}deg)`;
+}
+
+/** 持ち上がった高さに応じて影を伸ばす（紙が浮けば影は遠く・淡く・ぼける） */
+function stackShadow(progress) {
+    const height = Math.max(stackParts(progress).z, 0);
+    const y = 1.5 + height * 0.22;
+    const blur = 5 + height * 0.5;
+    const alpha = 0.16 + Math.min(height / SLIDE_LIFT, 1) * 0.1;
+    // 1層目＝紙同士の接地影、2層目＝浮いた高さぶんの落ち影
+    return `0 1px 2px rgba(74, 59, 50, 0.16), 0 ${y.toFixed(1)}px ${blur.toFixed(1)}px rgba(74, 59, 50, ${alpha.toFixed(3)})`;
+}
+
+function transformAt(progress, single) {
+    return single ? stackTransform(progress) : bookTransform(progress);
+}
+
+/** 経路を等間隔にサンプリングしてキーフレームにする */
+function framesBetween(from, to, single) {
+    const steps = single ? 12 : 2;
+    return Array.from({ length: steps + 1 }, (_, i) => {
+        const offset = i / steps;
+        const progress = from + (to - from) * offset;
+        const frame = { transform: transformAt(progress, single), offset };
+        if (single) frame.boxShadow = stackShadow(progress);
+        return frame;
+    });
+}
+
+function clamp(value, min, max) {
+    return Math.min(Math.max(value, min), max);
+}
+
+function isSinglePage() {
+    return (
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia(SINGLE_PAGE_MQ).matches
+    );
+}
+
+function prefersReducedMotion() {
+    return (
+        typeof window !== 'undefined' &&
+        typeof window.matchMedia === 'function' &&
+        window.matchMedia('(prefers-reduced-motion: reduce)').matches
+    );
+}
+
 // SSR では useLayoutEffect が警告を出すので切り替える
 const useIsoLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
 
@@ -37,7 +121,7 @@ function LeftPage({ item, index, total }) {
         <div className={styles.pageInner}>
             <div className={styles.photoFrame}>
                 {item.thumbnail ? (
-                    <img src={item.thumbnail} alt={item.title} className={styles.photo} />
+                    <img src={item.thumbnail} alt={item.title} className={styles.photo} draggable={false} />
                 ) : (
                     <div className={styles.noPhoto}>No Image</div>
                 )}
@@ -63,7 +147,7 @@ function RightPage({ item, index }) {
 
             {item.thumbnail && (
                 <div className={styles.mobilePhoto}>
-                    <img src={item.thumbnail} alt="" className={styles.photo} />
+                    <img src={item.thumbnail} alt="" className={styles.photo} draggable={false} />
                 </div>
             )}
 
@@ -92,33 +176,45 @@ export default function MakesBook({ items }) {
     const total = list.length;
 
     const [index, setIndex] = useState(0);
-    // flip: { dir: 'next' | 'prev', from, to }
+    // flip: { dir: 'next' | 'prev', from, to, mode: 'auto' | 'drag' }
     const [flip, setFlip] = useState(null);
     const [paused, setPaused] = useState(false);
+    const [dragging, setDragging] = useState(false);
+    const spreadRef = useRef(null);
     const sheetRef = useRef(null);
     const animRef = useRef(null);
+    const dragRef = useRef(null);
+
+    const nextIndex = useCallback(
+        (dir) => (dir === 'next' ? (index + 1) % total : (index - 1 + total) % total),
+        [index, total]
+    );
 
     const turn = useCallback(
         (dir) => {
             if (total < 2) return;
             setFlip((current) => {
                 if (current) return current; // めくり中は無視
-                const to = dir === 'next' ? (index + 1) % total : (index - 1 + total) % total;
-                return { dir, from: index, to };
+                return { dir, from: index, to: nextIndex(dir), mode: 'auto' };
             });
         },
-        [index, total]
+        [index, total, nextIndex]
     );
 
-    // めくりアニメーション（進む／戻るのどちらも同じ経路を逆再生する）
+    // ボタン／キー操作でのめくり（進む・戻るで同じ軌道を順・逆再生）
     useIsoLayoutEffect(() => {
         if (!flip) {
             if (animRef.current) {
                 animRef.current.cancel();
                 animRef.current = null;
             }
+            if (sheetRef.current) {
+                sheetRef.current.style.transform = '';
+                sheetRef.current.style.boxShadow = '';
+            }
             return undefined;
         }
+        if (flip.mode !== 'auto') return undefined;
 
         const el = sheetRef.current;
         const commit = () => {
@@ -131,22 +227,12 @@ export default function MakesBook({ items }) {
             return () => clearTimeout(id);
         }
 
-        const reduced =
-            typeof window !== 'undefined' &&
-            window.matchMedia &&
-            window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-
-        // 開いた本の傾きに合わせて、右ページ位置から左ページ位置へ半回転させる
-        const sequence = [
-            `rotateY(${-TILT}deg)`, // 右ページの位置
-            'rotateY(-90deg) translateZ(30px)', // 立ち上がった瞬間
-            `rotateY(${-180 + TILT}deg)`, // 左ページの位置
-        ];
-        const order = flip.dir === 'next' ? sequence : [...sequence].reverse();
-        const frames = order.map((transform, i) => ({ transform, offset: [0, 0.5, 1][i] }));
+        const single = isSinglePage();
+        const frames =
+            flip.dir === 'next' ? framesBetween(0, 1, single) : framesBetween(1, 0, single);
 
         const anim = el.animate(frames, {
-            duration: reduced ? 1 : FLIP_MS,
+            duration: prefersReducedMotion() ? 1 : FLIP_MS,
             easing: 'cubic-bezier(0.45, 0.05, 0.4, 1)',
             fill: 'forwards',
         });
@@ -165,6 +251,155 @@ export default function MakesBook({ items }) {
         const id = setTimeout(() => turn('next'), AUTOPLAY_MS);
         return () => clearTimeout(id);
     }, [paused, total, flip, turn]);
+
+    // ===== 指／マウスでページをつまんでめくる =====
+
+    /** 綴じ目の位置とページ幅（片ページ表示のときは綴じ目が左端） */
+    const geometry = useCallback(() => {
+        const rect = spreadRef.current.getBoundingClientRect();
+        const single = isSinglePage();
+        return {
+            rect,
+            gutterX: single ? rect.left : rect.left + rect.width / 2,
+            width: single ? rect.width : rect.width / 2,
+            single,
+        };
+    }, []);
+
+    /** 紙の端がポインタに付いてくるように、X座標からめくり具合を求める */
+    const progressFromX = useCallback((clientX, geo) => {
+        const ratio = clamp((clientX - geo.gutterX) / geo.width, -1, 1);
+        return Math.acos(ratio) / Math.PI;
+    }, []);
+
+    /** 紙束モード：指の移動距離をそのまま「後ろへ回す」進捗に割り当てる */
+    const stackProgress = useCallback((dx, dir, width) => {
+        const travel = SLIDE_TRAVEL * width;
+        return dir === 'next' ? clamp(-dx / travel, 0, 1) : 1 - clamp(dx / travel, 0, 1);
+    }, []);
+
+    const handlePointerDown = useCallback(
+        (event) => {
+            if (total < 2 || flip || dragRef.current) return;
+            if (event.pointerType === 'mouse' && event.button !== 0) return; // 左ボタンのみ
+            if (event.target.closest('a, button')) return;
+
+            const geo = geometry();
+            const relative = (event.clientX - geo.rect.left) / geo.rect.width;
+            const dir = relative < (geo.single ? 0.3 : 0.5) ? 'prev' : 'next';
+
+            dragRef.current = {
+                dir,
+                geo,
+                to: nextIndex(dir),
+                pointerId: event.pointerId,
+                startX: event.clientX,
+                lastX: event.clientX,
+                lastAt: performance.now(),
+                velocity: 0,
+                progress: dir === 'next' ? 0 : 1,
+                engaged: false,
+            };
+            setPaused(true);
+            event.currentTarget.setPointerCapture(event.pointerId);
+        },
+        [total, flip, geometry, nextIndex]
+    );
+
+    const handlePointerMove = useCallback(
+        (event) => {
+            const drag = dragRef.current;
+            if (!drag || event.pointerId !== drag.pointerId) return;
+
+            const dx = event.clientX - drag.startX;
+            if (!drag.engaged) {
+                if (Math.abs(dx) < DRAG_START_PX) return;
+                // 進むなら左へ、戻るなら右へ動かしたときだけ紙を持ち上げる
+                if ((drag.dir === 'next' && dx > 0) || (drag.dir === 'prev' && dx < 0)) return;
+                drag.engaged = true;
+                setDragging(true);
+                setFlip({ dir: drag.dir, from: index, to: drag.to, mode: 'drag' });
+            }
+
+            const now = performance.now();
+            drag.velocity = (event.clientX - drag.lastX) / Math.max(now - drag.lastAt, 1);
+            drag.lastX = event.clientX;
+            drag.lastAt = now;
+            drag.progress = drag.geo.single
+                ? stackProgress(dx, drag.dir, drag.geo.width)
+                : progressFromX(event.clientX, drag.geo);
+
+            if (sheetRef.current) {
+                sheetRef.current.style.transform = transformAt(drag.progress, drag.geo.single);
+                sheetRef.current.style.boxShadow = drag.geo.single ? stackShadow(drag.progress) : '';
+            }
+        },
+        [index, progressFromX, stackProgress]
+    );
+
+    const finishDrag = useCallback(
+        (event, cancelled) => {
+            const drag = dragRef.current;
+            if (!drag || event.pointerId !== drag.pointerId) return;
+            dragRef.current = null;
+            setPaused(false);
+            try {
+                event.currentTarget.releasePointerCapture(drag.pointerId);
+            } catch {
+                /* すでに解放済み */
+            }
+
+            // ほとんど動いていなければタップ扱いでめくる（縦スクロール等で中断されたときは何もしない）
+            if (!drag.engaged) {
+                if (!cancelled && Math.abs(event.clientX - drag.startX) < DRAG_START_PX) turn(drag.dir);
+                return;
+            }
+
+            setDragging(false);
+
+            const el = sheetRef.current;
+            const towardEnd =
+                (drag.dir === 'next' && drag.velocity < 0) || (drag.dir === 'prev' && drag.velocity > 0);
+            const flicked = Math.abs(drag.velocity) > FLICK_VELOCITY && towardEnd;
+            const passedHalf = drag.dir === 'next' ? drag.progress > 0.5 : drag.progress < 0.5;
+            const complete = !cancelled && (flicked || passedHalf);
+
+            const target = drag.dir === 'next' ? (complete ? 1 : 0) : complete ? 0 : 1;
+            const settle = () => {
+                if (complete) setIndex(drag.to);
+                setFlip(null);
+            };
+
+            if (!el || typeof el.animate !== 'function') {
+                settle();
+                return;
+            }
+
+            const anim = el.animate(framesBetween(drag.progress, target, drag.geo.single), {
+                duration: prefersReducedMotion()
+                    ? 1
+                    : Math.max(160, Math.round(FLIP_MS * Math.abs(target - drag.progress))),
+                easing: 'cubic-bezier(0.22, 0.61, 0.36, 1)',
+                fill: 'forwards',
+            });
+            animRef.current = anim;
+            anim.onfinish = settle;
+        },
+        [turn]
+    );
+
+    const handleKeyDown = useCallback(
+        (event) => {
+            if (event.key === 'ArrowRight' || event.key === 'PageDown') {
+                event.preventDefault();
+                turn('next');
+            } else if (event.key === 'ArrowLeft' || event.key === 'PageUp') {
+                event.preventDefault();
+                turn('prev');
+            }
+        },
+        [turn]
+    );
 
     if (total === 0) {
         return (
@@ -187,27 +422,45 @@ export default function MakesBook({ items }) {
     const leftLeaves = MIN_LEAVES + Math.round(ratio * (STACK_LEAVES - MIN_LEAVES * 2));
     const rightLeaves = STACK_LEAVES - leftLeaves;
 
+    const bookClass = [styles.book, total > 1 ? styles.bookGrabbable : '', dragging ? styles.bookDragging : '']
+        .filter(Boolean)
+        .join(' ');
     const sheetClass = `${styles.sheet}${flip ? ` ${styles.sheetVisible}` : ''}`;
 
     return (
         <div className={styles.bookWrapper}>
             <div
-                className={styles.book}
+                className={bookClass}
+                role="group"
+                aria-label="Makes の作品を収めた本。ドラッグまたは左右キーでページをめくれます"
+                tabIndex={0}
+                onPointerDown={handlePointerDown}
+                onPointerMove={handlePointerMove}
+                onPointerUp={(event) => finishDrag(event, false)}
+                onPointerCancel={(event) => finishDrag(event, true)}
+                onKeyDown={handleKeyDown}
                 onMouseEnter={() => setPaused(true)}
                 onMouseLeave={() => setPaused(false)}
-                onFocusCapture={() => setPaused(true)}
-                onBlurCapture={() => setPaused(false)}
+                onFocus={() => setPaused(true)}
+                onBlur={() => setPaused(false)}
             >
-                <div className={styles.spread}>
+                <div className={styles.spread} ref={spreadRef}>
+                    {total > 1 && (
+                        <>
+                            <span className={`${styles.underSheet} ${styles.underSheetC}`} aria-hidden="true" />
+                            <span className={`${styles.underSheet} ${styles.underSheetB}`} aria-hidden="true" />
+                            <span className={`${styles.underSheet} ${styles.underSheetA}`} aria-hidden="true" />
+                        </>
+                    )}
                     <div
                         className={`${styles.page} ${styles.pageLeft}`}
-                        style={{ boxShadow: leafStack(leftLeaves, -1) }}
+                        style={{ '--leaf-stack': leafStack(leftLeaves, -1) }}
                     >
                         <LeftPage item={list[staticLeft]} index={staticLeft} total={total} />
                     </div>
                     <div
                         className={`${styles.page} ${styles.pageRight}`}
-                        style={{ boxShadow: leafStack(rightLeaves, 1) }}
+                        style={{ '--leaf-stack': leafStack(rightLeaves, 1) }}
                     >
                         <RightPage item={list[staticRight]} index={staticRight} />
                     </div>
@@ -227,46 +480,14 @@ export default function MakesBook({ items }) {
                     <span className={styles.gutter} aria-hidden="true" />
                 </div>
 
-                {total > 1 && (
-                    <>
-                        <button
-                            type="button"
-                            className={`${styles.corner} ${styles.cornerPrev}`}
-                            onClick={() => turn('prev')}
-                            aria-label="前のページ"
-                        />
-                        <button
-                            type="button"
-                            className={`${styles.corner} ${styles.cornerNext}`}
-                            onClick={() => turn('next')}
-                            aria-label="次のページ"
-                        />
-                    </>
-                )}
+                {total > 1 && <span className={styles.curl} aria-hidden="true" />}
             </div>
 
             <div className={styles.controls}>
-                <button
-                    type="button"
-                    className={styles.navButton}
-                    onClick={() => turn('prev')}
-                    disabled={total < 2}
-                    aria-label="前のページ"
-                >
-                    ‹
-                </button>
-                <span className={styles.counter}>
+                <span className={styles.counter} aria-live="polite">
                     {String(index + 1).padStart(2, '0')} <em>/</em> {String(total).padStart(2, '0')}
                 </span>
-                <button
-                    type="button"
-                    className={styles.navButton}
-                    onClick={() => turn('next')}
-                    disabled={total < 2}
-                    aria-label="次のページ"
-                >
-                    ›
-                </button>
+                {total > 1 && <span className={styles.hint}>ページの端をつまんでめくる</span>}
             </div>
 
             <div className={styles.moreButtonWrapper}>

--- a/components/MakesBook.module.css
+++ b/components/MakesBook.module.css
@@ -16,6 +16,11 @@
     border-radius: 6px 10px 10px 6px / 8px 12px 12px 8px;
     transform-style: preserve-3d;
     transform: rotateX(5deg);
+    /* 縦スクロールは残しつつ、横方向のドラッグはページめくりに使う */
+    touch-action: pan-y;
+    user-select: none;
+    -webkit-user-select: none;
+    -webkit-tap-highlight-color: transparent;
     /* 革の表紙 */
     background:
         linear-gradient(180deg, rgba(0, 0, 0, 0.12), rgba(0, 0, 0, 0) 22%),
@@ -55,6 +60,8 @@
     width: 50%;
     height: 100%;
     overflow: hidden;
+    /* 小口（紙束）の厚み。枚数に応じて JS から差し込む */
+    box-shadow: var(--leaf-stack, none);
     background:
         linear-gradient(180deg, #fdf8ee 0%, #f7eddc 100%);
 }
@@ -101,6 +108,17 @@
             rgba(74, 59, 50, 0.1) 88%,
             rgba(74, 59, 50, 0.34) 100%);
     border-radius: 2px 10px 10px 2px;
+}
+
+/* 下に重なっている紙（スマホの紙束表示でのみ出す） */
+.underSheet {
+    display: none;
+    position: absolute;
+    inset: 0;
+    border-radius: 3px 10px 10px 3px;
+    background: linear-gradient(180deg, #f9f2e4 0%, #efe3cd 100%);
+    border: 1px solid rgba(74, 59, 50, 0.09);
+    box-shadow: 0 1px 2px rgba(74, 59, 50, 0.16);
 }
 
 /* 綴じ目（ノド） */
@@ -410,82 +428,57 @@
     cursor: default;
 }
 
-/* ===== ページの角（クリックでめくる） ===== */
-.corner {
+/* ===== つまんでめくる ===== */
+.bookGrabbable {
+    cursor: grab;
+}
+
+.bookDragging {
+    cursor: grabbing;
+}
+
+.book:focus-visible {
+    outline: 2px solid var(--c-accent-1);
+    outline-offset: 8px;
+}
+
+/* 右下の角が少し反り返って「つまめる」ことを示す */
+.curl {
     position: absolute;
-    bottom: 14px;
-    width: 84px;
-    height: 100px;
-    padding: 0;
-    border: none;
-    background: transparent;
-    cursor: pointer;
+    right: 24px;
+    bottom: 22px;
+    width: 78px;
+    height: 92px;
+    border-radius: 0 0 10px 0;
+    background: linear-gradient(225deg, rgba(74, 59, 50, 0.26) 0%, rgba(74, 59, 50, 0.07) 42%, rgba(74, 59, 50, 0) 56%);
+    opacity: 0.55;
+    transition: opacity 0.3s ease;
+    pointer-events: none;
     z-index: 9;
 }
 
-.cornerNext {
-    right: 16px;
-}
-
-.cornerPrev {
-    left: 16px;
-}
-
-.corner::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    opacity: 0;
-    transition: opacity 0.3s ease;
-}
-
-.cornerNext::after {
-    background: linear-gradient(225deg, rgba(74, 59, 50, 0.28) 0%, rgba(74, 59, 50, 0.07) 42%, rgba(74, 59, 50, 0) 55%);
-    border-radius: 0 0 10px 0;
-}
-
-.cornerPrev::after {
-    background: linear-gradient(135deg, rgba(74, 59, 50, 0.28) 0%, rgba(74, 59, 50, 0.07) 42%, rgba(74, 59, 50, 0) 55%);
-    border-radius: 0 0 0 10px;
-}
-
-.corner:hover::after,
-.corner:focus-visible::after {
+.bookGrabbable:hover .curl {
     opacity: 1;
+}
+
+.bookDragging .curl {
+    opacity: 0;
 }
 
 /* ===== 操作パネル ===== */
 .controls {
     display: flex;
+    flex-direction: column;
     align-items: center;
-    justify-content: center;
-    gap: 1rem;
+    gap: 0.5rem;
     margin-top: 3rem;
 }
 
-.navButton {
-    width: 34px;
-    height: 34px;
-    line-height: 1;
-    font-size: 1.2rem;
+.hint {
     font-family: var(--font-serif);
-    color: #6b4c33;
-    background: rgba(255, 253, 247, 0.7);
-    border: 1px solid rgba(139, 100, 64, 0.35);
-    border-radius: 50%;
-    cursor: pointer;
-    transition: all 0.3s;
-}
-
-.navButton:hover:not(:disabled) {
-    background: #6b4c33;
-    color: #fdf6ea;
-    border-color: #6b4c33;
-}
-
-.navButton:disabled {
-    opacity: 0.35;
-    cursor: default;
+    font-size: 0.78rem;
+    letter-spacing: 0.14em;
+    color: rgba(74, 59, 50, 0.45);
 }
 
 .counter {
@@ -542,11 +535,42 @@
 
 /* ===== レスポンシブ：狭い画面は片ページの本 ===== */
 @media (max-width: 760px) {
+    /* 革の表紙は出さず、重なった紙の束として見せる */
     .book {
-        width: min(340px, 100%);
-        aspect-ratio: 0.76;
-        padding: 8px 16px 16px;
+        /* 右にはみ出す紙束のぶん余白を残す */
+        width: min(320px, calc(100% - 44px));
+        aspect-ratio: 0.74;
+        padding: 0;
+        border-radius: 3px 10px 10px 3px;
         transform: rotateX(3deg);
+        background: none;
+        box-shadow: none;
+    }
+
+    /* 紙は平らなので、楕円のぼんやりした落ち影は使わない */
+    .book::after {
+        display: none;
+    }
+
+    .underSheet {
+        display: block;
+    }
+
+    .underSheetA {
+        transform: translate(5px, 6px) rotate(1deg) translateZ(-1px);
+    }
+
+    .underSheetB {
+        transform: translate(10px, 12px) rotate(-1.2deg) translateZ(-2px);
+    }
+
+    /* 束全体が机に落とす影は、一番下の紙にまとめて持たせる */
+    .underSheetC {
+        transform: translate(15px, 18px) rotate(2.4deg) translateZ(-3px);
+        opacity: 0.9;
+        box-shadow:
+            0 1px 2px rgba(74, 59, 50, 0.14),
+            0 16px 26px rgba(74, 59, 50, 0.2);
     }
 
     .pageLeft {
@@ -556,13 +580,41 @@
     .pageRight {
         width: 100%;
         border-radius: 3px 10px 10px 3px;
-        transform: rotateY(-4deg);
+        /* 束なので開き角はつけずに平らな紙にする */
+        transform: none;
     }
 
+    /* 階段状の小口はやめ、紙同士の接地影だけにする */
+    .page {
+        box-shadow: 0 1px 2px rgba(74, 59, 50, 0.16);
+    }
+
+    /* ページの湾曲を表す陰影は平らな紙には合わないので消す */
+    .page::after,
+    .sheetFace::after {
+        background: none;
+    }
+
+    /* 綴じ目のない束なので、ノドの影も出さない */
     .gutter {
-        width: 16px;
+        display: none;
+    }
+
+    .sheetFace {
+        box-shadow: none;
+    }
+
+    /* 綴じ側は革ではなく、紙が寄って落ちる影だけにする */
+    .gutter {
+        top: 0;
+        bottom: 0;
         left: 0;
+        width: 14px;
         transform: none;
+        background: linear-gradient(90deg,
+                rgba(74, 59, 50, 0.22) 0%,
+                rgba(74, 59, 50, 0.07) 55%,
+                rgba(74, 59, 50, 0) 100%);
     }
 
     .gutter::before,
@@ -570,16 +622,22 @@
         display: none;
     }
 
+    /* 束をめくる見せ方なので、挟むしおりは出さない */
     .ribbon {
-        left: 16px;
-        width: 10px;
-        transform-origin: -16px center;
-        transform: rotateY(-4deg);
+        display: none;
     }
 
+    /* 一番手前の紙：横へ抜けて束の後ろへ回る（奥行きで前後が決まる） */
     .sheet {
         left: 0;
         width: 100%;
+        border-radius: 3px 10px 10px 3px;
+        transform-origin: center center;
+        transform: translateZ(1px);
+        box-shadow:
+            0 1px 2px rgba(74, 59, 50, 0.16),
+            0 1.5px 5px rgba(74, 59, 50, 0.16);
+        z-index: auto;
     }
 
     .pageInner {
@@ -606,16 +664,19 @@
         box-shadow: 0 4px 10px rgba(74, 59, 50, 0.16);
     }
 
+    .curl {
+        right: 2px;
+        bottom: 4px;
+        width: 56px;
+        height: 68px;
+    }
+
     .description {
         -webkit-line-clamp: 4;
         font-size: 0.9rem;
         line-height: 1.8;
     }
 
-    .corner {
-        width: 60px;
-        height: 74px;
-    }
 }
 
 


### PR DESCRIPTION
Closes #48

## 操作

- Pointer Events でつまんでめくる方式に変更。**紙の端がポインタに付いてくる**ように、X 座標から `acos` で角度を逆算しています（マウス・タッチ・ペンが同じコード経路）
- 離したときは**半分を超えていればめくり切り、超えていなければ元に戻す**。勢いよく払った場合（0.5px/ms 以上）は半分未満でも完了させます。残りの角度に比例した時間でスナップします
- `touch-action: pan-y` で縦スクロールは従来どおり。縦スクロールに取られて中断（pointercancel）したときはページを送らずに戻します
- ほぼ動かさずに離したらタップ扱いで 1 ページ送り（電子書籍と同じ感覚）
- 下の前後ボタンと角のクリックボタンを廃止。代わりに右下の角に反り返りの影（つまめる合図）を出し、カーソルは `grab / grabbing`。キーボードは ←→（PageUp/Down）に対応し、ページ番号は `aria-live` で読み上げます

## スマホ表示（760px 以下）

見開きを片ページにすると革の額縁がバインダーに見えるため、**表紙を出さず紙の束**として見せる方針に変更しました。

- めくりではなく、**一番手前の紙が横へ抜けて → 持ち上がり → 束の後ろへ回り込む**アニメーション（`stackTransform()`）
- 前後関係は `z-index` ではなく 3D の奥行きで解決（`preserve-3d` の深度ソート）
- 下に重なる紙を実要素で 3 枚敷き、少しずつ回転をずらして無造作な束にする
- 本向けの陰影を紙束用に作り直し: 階段状の小口・ノドの影・ページの湾曲の陰影・楕円の落ち影を無効化。**束全体の落ち影は一番下の紙**が持ち、上の紙は接地影のみ。持ち上がった紙の影は高さに応じて伸びる（`stackShadow()`）
- 挟むしおりは非表示

デスクトップの見開き（革表紙・小口・ノドの陰影・しおり）は変更していません。

## 確認したこと

- `npx next build` 成功
- ローカルの dev サーバーで実データ（KV の makes）の描画を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)