### PR TITLE
feat(top): 本の View Project ボタンをやめてタイトルをリンクにする

### DIFF
--- a/components/MakesBook.js
+++ b/components/MakesBook.js
@@ -136,13 +136,30 @@ function LeftPage({ item, index, total }) {
     );
 }
 
-/** 右ページ（作品の記述） */
+/** 右ページ（作品の記述）。見出しが作品へのリンクになる */
 function RightPage({ item, index }) {
     if (!item) return <div className={styles.pageInner} />;
+
     return (
         <div className={styles.pageInner}>
             <p className={styles.chapter}>Makes</p>
-            <h3 className={styles.title}>{item.title}</h3>
+
+            <h3 className={styles.title}>
+                {item.externalUrl ? (
+                    <Link
+                        href={item.externalUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className={styles.titleLink}
+                        aria-label={`${item.title} を新しいタブで開く`}
+                    >
+                        {item.title}
+                        <span className={styles.openMark}>↗</span>
+                    </Link>
+                ) : (
+                    item.title
+                )}
+            </h3>
             <span className={styles.rule} aria-hidden="true" />
 
             {item.thumbnail && (
@@ -157,15 +174,6 @@ function RightPage({ item, index }) {
                 <TechBadgeList techStack={item.techStack} limit={4} />
             </div>
 
-            <div className={styles.pageFooter}>
-                {item.externalUrl ? (
-                    <Link href={item.externalUrl} target="_blank" className={styles.link}>
-                        View Project →
-                    </Link>
-                ) : (
-                    <span className={styles.noLink}>View Details</span>
-                )}
-            </div>
             <span className={styles.folio}>{index * 2 + 2}</span>
         </div>
     );
@@ -184,6 +192,8 @@ export default function MakesBook({ items }) {
     const sheetRef = useRef(null);
     const animRef = useRef(null);
     const dragRef = useRef(null);
+    // ドラッグでめくったときは、そのまま続くクリック（リンク）を打ち消す
+    const suppressClickRef = useRef(false);
 
     const nextIndex = useCallback(
         (dir) => (dir === 'next' ? (index + 1) % total : (index - 1 + total) % total),
@@ -280,9 +290,10 @@ export default function MakesBook({ items }) {
 
     const handlePointerDown = useCallback(
         (event) => {
+            suppressClickRef.current = false;
             if (total < 2 || flip || dragRef.current) return;
             if (event.pointerType === 'mouse' && event.button !== 0) return; // 左ボタンのみ
-            if (event.target.closest('a, button')) return;
+            if (event.target.closest('button')) return;
 
             const geo = geometry();
             const relative = (event.clientX - geo.rect.left) / geo.rect.width;
@@ -291,6 +302,9 @@ export default function MakesBook({ items }) {
             dragRef.current = {
                 dir,
                 geo,
+                // リンクの上から始めた場合、動かさずに離したらリンクを優先する
+                onLink: Boolean(event.target.closest('a')),
+                moved: false,
                 to: nextIndex(dir),
                 pointerId: event.pointerId,
                 startX: event.clientX,
@@ -312,6 +326,7 @@ export default function MakesBook({ items }) {
             if (!drag || event.pointerId !== drag.pointerId) return;
 
             const dx = event.clientX - drag.startX;
+            if (Math.abs(dx) >= DRAG_START_PX) drag.moved = true;
             if (!drag.engaged) {
                 if (Math.abs(dx) < DRAG_START_PX) return;
                 // 進むなら左へ、戻るなら右へ動かしたときだけ紙を持ち上げる
@@ -349,9 +364,12 @@ export default function MakesBook({ items }) {
                 /* すでに解放済み */
             }
 
-            // ほとんど動いていなければタップ扱いでめくる（縦スクロール等で中断されたときは何もしない）
+            suppressClickRef.current = drag.moved;
+
+            // ほとんど動いていなければタップ扱いでめくる。
+            // ただしリンクの上なら、そのリンクを開く方を優先する
             if (!drag.engaged) {
-                if (!cancelled && Math.abs(event.clientX - drag.startX) < DRAG_START_PX) turn(drag.dir);
+                if (!cancelled && !drag.onLink && !drag.moved) turn(drag.dir);
                 return;
             }
 
@@ -434,6 +452,12 @@ export default function MakesBook({ items }) {
                 role="group"
                 aria-label="Makes の作品を収めた本。ドラッグまたは左右キーでページをめくれます"
                 tabIndex={0}
+                onClickCapture={(event) => {
+                    if (!suppressClickRef.current) return;
+                    suppressClickRef.current = false;
+                    event.preventDefault();
+                    event.stopPropagation();
+                }}
                 onPointerDown={handlePointerDown}
                 onPointerMove={handlePointerMove}
                 onPointerUp={(event) => finishDrag(event, false)}

--- a/components/MakesBook.module.css
+++ b/components/MakesBook.module.css
@@ -318,6 +318,15 @@
     letter-spacing: 0.1em;
 }
 
+.openMark {
+    display: inline-block;
+    margin-left: 0.35em;
+    font-size: 0.72em;
+    color: var(--c-accent-1);
+    opacity: 0.55;
+    transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
 /* マスキングテープ */
 .tape {
     position: absolute;
@@ -366,12 +375,37 @@
     text-shadow: 0 1px 0 rgba(255, 255, 255, 0.8);
 }
 
+/* 見出しがそのまま作品へのリンクになる */
+.titleLink {
+    color: inherit;
+    text-decoration: none;
+    transition: color 0.3s ease;
+}
+
+.titleLink:hover,
+.titleLink:focus-visible {
+    color: var(--c-accent-1);
+}
+
+.titleLink:hover .openMark,
+.titleLink:focus-visible .openMark {
+    opacity: 1;
+    transform: translate(2px, -2px);
+}
+
 .rule {
     display: block;
     width: 60px;
     height: 2px;
     margin: 0.9rem 0 1.1rem;
     background: linear-gradient(90deg, var(--c-gear-gold), rgba(255, 177, 66, 0));
+    transition: width 0.35s ease;
+}
+
+/* 見出しにホバーしたときだけ罫線が伸びる */
+.title:hover + .rule,
+.title:focus-within + .rule {
+    width: 96px;
 }
 
 .mobilePhoto {
@@ -380,52 +414,19 @@
 
 .description {
     font-family: var(--font-serif);
-    font-size: 0.95rem;
-    line-height: 1.95;
+    font-size: 0.92rem;
+    line-height: 1.78;
     color: #5b4a3e;
+    text-align: justify;
     display: -webkit-box;
-    -webkit-line-clamp: 5;
+    -webkit-line-clamp: 10;
     -webkit-box-orient: vertical;
     overflow: hidden;
-    margin-bottom: 1.2rem;
+    margin-bottom: 1rem;
 }
 
 .techArea {
     margin-top: auto;
-}
-
-.pageFooter {
-    margin-top: 0.4rem;
-}
-
-.link,
-.noLink {
-    display: inline-block;
-    padding: 0.45rem 1.1rem;
-    font-family: var(--font-serif);
-    font-size: 0.85rem;
-    letter-spacing: 0.04em;
-    font-weight: 600;
-    color: #6b4c33;
-    text-decoration: none;
-    background: rgba(255, 253, 247, 0.9);
-    border: 1px solid rgba(139, 100, 64, 0.45);
-    border-radius: 3px;
-    transition: all 0.3s;
-}
-
-.link:hover {
-    background: #6b4c33;
-    color: #fdf6ea;
-    border-color: #6b4c33;
-    transform: translateX(4px);
-}
-
-.noLink {
-    background: rgba(139, 100, 64, 0.06);
-    color: rgba(74, 59, 50, 0.35);
-    border-color: rgba(139, 100, 64, 0.2);
-    cursor: default;
 }
 
 /* ===== つまんでめくる ===== */
@@ -672,9 +673,9 @@
     }
 
     .description {
-        -webkit-line-clamp: 4;
-        font-size: 0.9rem;
-        line-height: 1.8;
+        -webkit-line-clamp: 6;
+        font-size: 0.86rem;
+        line-height: 1.75;
     }
 
 }


### PR DESCRIPTION
Closes #52

本の中のボタンが世界観から浮いていたため、見た人が直感的に押す場所（説明文の上の作品タイトル）をそのまま導線にしました。

## 変更

- **「View Project →」ボタンを廃止**。タイトルから新しいタブで作品を開きます
- 押せることは、ホバーでの**アクセント色 → 箔押し罫線が伸びる → 末尾の ↗ が濃くなる**の 3 つで示し、ボタンの見た目は使いません
- **導線はタイトル 1 箇所だけ**。写真やドメイン表記はリンクにしていません
- 本文（説明文）を **5 行 → 10 行**（スマホは 4 行 → 6 行）に増量。行間 1.95 → 1.78、字送りを詰め、両端揃えにして本文らしくしました

## ドラッグとの共存

ページめくりのドラッグはリンクの上からでも始められます。

- 少しでも動かしたら、続くクリックを `onClickCapture` で打ち消す（めくったのにリンクが開く事故を防ぐ）
- リンクの上で動かさずに離したときは、ページを送らずにリンクを開く
- リンク以外の場所で動かさずに離したときは、これまで通りタップでページ送り

## アクセシビリティ

- タブ移動の対象はタイトルのリンク 1 つ。`aria-label` に「（作品名）を新しいタブで開く」を設定

## 確認したこと

- `npx next build` 成功
- dev サーバーで、ボタンとドメイン表記が消えタイトルのリンクだけになっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)