### PR TITLE
feat(top): 本をめくるときの紙擦れ音を追加

### DIFF
--- a/components/MakesBook.js
+++ b/components/MakesBook.js
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import Link from 'next/link';
 import TechBadgeList from './TechBadgeList';
+import { isMuted, playRustle, setMuted } from './paperSound';
 import styles from './MakesBook.module.css';
 
 const FLIP_MS = 950;
@@ -188,6 +189,7 @@ export default function MakesBook({ items }) {
     const [flip, setFlip] = useState(null);
     const [paused, setPaused] = useState(false);
     const [dragging, setDragging] = useState(false);
+    const [soundOff, setSoundOff] = useState(false);
     const spreadRef = useRef(null);
     const sheetRef = useRef(null);
     const animRef = useRef(null);
@@ -200,11 +202,19 @@ export default function MakesBook({ items }) {
         [index, total]
     );
 
+    // 保存されているミュート設定を反映する
+    useEffect(() => {
+        setSoundOff(isMuted());
+    }, []);
+
     const turn = useCallback(
-        (dir) => {
+        (dir, options) => {
             if (total < 2) return;
+            const silent = Boolean(options && options.silent);
             setFlip((current) => {
                 if (current) return current; // めくり中は無視
+                // 紙が動き出すのに合わせて鳴らす（自動めくりは鳴らさない）
+                if (!silent) playRustle(0.9);
                 return { dir, from: index, to: nextIndex(dir), mode: 'auto' };
             });
         },
@@ -258,7 +268,7 @@ export default function MakesBook({ items }) {
     // 自動でページをめくる
     useEffect(() => {
         if (paused || total < 2 || flip) return;
-        const id = setTimeout(() => turn('next'), AUTOPLAY_MS);
+        const id = setTimeout(() => turn('next', { silent: true }), AUTOPLAY_MS);
         return () => clearTimeout(id);
     }, [paused, total, flip, turn]);
 
@@ -333,6 +343,7 @@ export default function MakesBook({ items }) {
                 if ((drag.dir === 'next' && dx > 0) || (drag.dir === 'prev' && dx < 0)) return;
                 drag.engaged = true;
                 setDragging(true);
+                playRustle(0.5); // 紙を持ち上げる音
                 setFlip({ dir: drag.dir, from: index, to: drag.to, mode: 'drag' });
             }
 
@@ -381,6 +392,9 @@ export default function MakesBook({ items }) {
             const flicked = Math.abs(drag.velocity) > FLICK_VELOCITY && towardEnd;
             const passedHalf = drag.dir === 'next' ? drag.progress > 0.5 : drag.progress < 0.5;
             const complete = !cancelled && (flicked || passedHalf);
+
+            // 払った勢いが強いほど大きく鳴らす
+            playRustle(complete ? 0.8 + Math.min(Math.abs(drag.velocity), 1.5) * 0.25 : 0.3);
 
             const target = drag.dir === 'next' ? (complete ? 1 : 0) : complete ? 0 : 1;
             const settle = () => {
@@ -508,9 +522,26 @@ export default function MakesBook({ items }) {
             </div>
 
             <div className={styles.controls}>
-                <span className={styles.counter} aria-live="polite">
-                    {String(index + 1).padStart(2, '0')} <em>/</em> {String(total).padStart(2, '0')}
-                </span>
+                <div className={styles.counterRow}>
+                    <span className={styles.counter} aria-live="polite">
+                        {String(index + 1).padStart(2, '0')} <em>/</em> {String(total).padStart(2, '0')}
+                    </span>
+                    <button
+                        type="button"
+                        className={styles.soundToggle}
+                        onClick={() => {
+                            const next = !soundOff;
+                            setMuted(next);
+                            setSoundOff(next);
+                            if (!next) playRustle(0.6); // 音を戻したら手応えを返す
+                        }}
+                        aria-pressed={soundOff}
+                        aria-label={soundOff ? 'めくる音を鳴らす' : 'めくる音を消す'}
+                        title={soundOff ? 'めくる音を鳴らす' : 'めくる音を消す'}
+                    >
+                        {soundOff ? '🔇' : '🔊'}
+                    </button>
+                </div>
                 {total > 1 && <span className={styles.hint}>ページの端をつまんでめくる</span>}
             </div>
 

--- a/components/MakesBook.module.css
+++ b/components/MakesBook.module.css
@@ -482,6 +482,35 @@
     color: rgba(74, 59, 50, 0.45);
 }
 
+.counterRow {
+    display: flex;
+    align-items: center;
+    gap: 0.7rem;
+}
+
+/* めくる音のオン・オフ */
+.soundToggle {
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    font-size: 0.8rem;
+    line-height: 1;
+    color: var(--c-text-secondary);
+    background: rgba(255, 253, 247, 0.65);
+    border: 1px solid rgba(139, 100, 64, 0.3);
+    border-radius: 50%;
+    cursor: pointer;
+    opacity: 0.6;
+    transition: opacity 0.3s ease, border-color 0.3s ease, background 0.3s ease;
+}
+
+.soundToggle:hover,
+.soundToggle:focus-visible {
+    opacity: 1;
+    border-color: var(--c-accent-1);
+    background: rgba(255, 253, 247, 0.95);
+}
+
 .counter {
     font-family: var(--font-serif);
     font-size: 0.9rem;

--- a/components/paperSound.js
+++ b/components/paperSound.js
@@ -1,0 +1,139 @@
+'use client';
+
+/**
+ * 紙をめくる音を WebAudio で合成する。
+ * 音源ファイルは持たず、短いノイズの粒を重ねて乾いた紙の擦れを作る。
+ * 自動再生の制約があるため、AudioContext は最初のユーザー操作時に作る。
+ */
+
+const STORAGE_KEY = 'makes-book-sound';
+const NOISE_SECONDS = 0.6;
+
+let context = null;
+let noiseBuffer = null;
+let muted = false;
+let initialized = false;
+
+/** 保存されている設定を読む（初回だけ） */
+export function isMuted() {
+    if (!initialized && typeof window !== 'undefined') {
+        initialized = true;
+        try {
+            muted = window.localStorage.getItem(STORAGE_KEY) === 'off';
+        } catch {
+            muted = false;
+        }
+    }
+    return muted;
+}
+
+export function setMuted(value) {
+    muted = value;
+    initialized = true;
+    try {
+        window.localStorage.setItem(STORAGE_KEY, value ? 'off' : 'on');
+    } catch {
+        /* 保存できなくても音の切り替え自体は効く */
+    }
+}
+
+function getContext() {
+    if (context) return context;
+    const Ctor = typeof window !== 'undefined' && (window.AudioContext || window.webkitAudioContext);
+    if (!Ctor) return null;
+    context = new Ctor();
+    return context;
+}
+
+function getNoise(ctx) {
+    if (noiseBuffer) return noiseBuffer;
+    const length = Math.floor(ctx.sampleRate * NOISE_SECONDS);
+    noiseBuffer = ctx.createBuffer(1, length, ctx.sampleRate);
+    const data = noiseBuffer.getChannelData(0);
+    for (let i = 0; i < length; i += 1) {
+        data[i] = Math.random() * 2 - 1;
+    }
+    return noiseBuffer;
+}
+
+/**
+ * 短い粒を 1 つ鳴らす。紙のパリッとした鳴りは、立ち上がりの速さと高域で決まる。
+ */
+function grain(ctx, destination, at, { duration, frequency, q, peak }) {
+    const source = ctx.createBufferSource();
+    source.buffer = getNoise(ctx);
+    source.playbackRate.value = 0.8 + Math.random() * 0.6;
+    // 毎回ノイズの違う場所を読む
+    const offset = Math.random() * (NOISE_SECONDS - duration - 0.01);
+
+    const band = ctx.createBiquadFilter();
+    band.type = 'bandpass';
+    band.frequency.value = frequency;
+    band.Q.value = q;
+
+    const gain = ctx.createGain();
+    gain.gain.setValueAtTime(0.0001, at);
+    // 3ms 程度で立ち上げる。速すぎるとパチパチした点の音になる
+    gain.gain.linearRampToValueAtTime(peak, at + 0.003);
+    gain.gain.exponentialRampToValueAtTime(0.0001, at + duration);
+
+    source.connect(band).connect(gain).connect(destination);
+    source.start(at, offset, duration + 0.01);
+    source.stop(at + duration + 0.02);
+}
+
+/**
+ * 紙をめくる音を一度鳴らす。
+ * なめらかな一発ではなく、短い粒を不揃いに重ねて乾いた擦れにする。
+ * @param {number} intensity 0〜1.2 程度。持ち上げは弱く、めくり切りは強く
+ */
+export function playRustle(intensity = 1) {
+    if (isMuted()) return;
+
+    const ctx = getContext();
+    if (!ctx) return;
+    if (ctx.state === 'suspended') ctx.resume();
+
+    const now = ctx.currentTime;
+    const strength = Math.max(0.15, Math.min(intensity, 1.2));
+
+    // 低域を切って紙らしい軽さを出す
+    const highpass = ctx.createBiquadFilter();
+    highpass.type = 'highpass';
+    highpass.frequency.value = 850;
+
+    // 上を少し丸めて、シャリつきを乾いた質感に寄せる
+    const lowpass = ctx.createBiquadFilter();
+    lowpass.type = 'lowpass';
+    lowpass.frequency.value = 9000;
+    lowpass.Q.value = 0.6;
+
+    const master = ctx.createGain();
+    master.gain.value = 0.42 * strength;
+    highpass.connect(lowpass).connect(master).connect(ctx.destination);
+
+    // 粒を重なるくらい密に並べる。粒が分離すると点の音、重なると乾いた擦れになる
+    const count = 7 + Math.round(strength * 6);
+    let at = now;
+    for (let i = 0; i < count; i += 1) {
+        const position = i / count;
+        // 単調に減衰させず、揺らして不均一な擦れにする
+        const wobble = (1 - position * 0.45) * (0.65 + Math.random() * 0.5);
+        grain(ctx, highpass, at, {
+            duration: 0.016 + Math.random() * 0.03,
+            frequency: 1500 + Math.random() * 3000,
+            // Q を下げるほど音程感が消えて、乾いた紙の擦れに近づく
+            q: 0.5 + Math.random() * 0.8,
+            peak: (0.05 + Math.random() * 0.05) * wobble,
+        });
+        at += 0.006 + Math.random() * 0.016;
+    }
+
+    // 最後に紙が落ち着く一撫で
+    grain(ctx, highpass, at, {
+        duration: 0.07 + strength * 0.04,
+        frequency: 1300 + Math.random() * 800,
+        q: 0.5,
+        peak: 0.045,
+    });
+}


### PR DESCRIPTION
Closes #54

音源ファイルは持たず、WebAudio で合成しました。ライセンスの確認も追加のダウンロードも不要で、操作の勢いに応じて質感を変えられます。

## 音の作り方

紙の音は「短い粒がたたみかける」音です。なめらかな包絡線のノイズを 1 発鳴らすと、それは砂の音の作り方そのもので紙には聞こえません。

- 16〜46ms の粒を **7〜15 個、不揃いな間隔で重ねる**
- バンドパスの **Q を 0.5〜1.3** に抑えて音程感を消す（高いと「キン」と鳴る）
- 立ち上がりは **3ms**。速すぎるとクリック音、遅すぎると砂の音になる
- 1.1kHz 以下と 9kHz 以上を落として紙の帯域に絞る
- ノイズバッファは初回に一度だけ生成して使い回す（連打しても詰まらない）

## 鳴らす場面

| きっかけ | 強さ |
| --- | --- |
| 紙を持ち上げた瞬間（ドラッグ開始） | 0.5 |
| めくり切って離した | 0.8＋払った勢いに比例 |
| 途中で戻した | 0.3 |
| タップ・キー操作でのめくり | 0.9 |
| 自動めくり（6 秒ごと） | 鳴らさない |

自動めくりで鳴らさないのは、うるさいことに加えて、**ユーザー操作を伴わない再生はブラウザにブロックされる**ためです。`AudioContext` の生成自体を「最初に鳴らす瞬間＝操作中」まで遅らせ、`suspended` なら `resume()` しています。

## ミュート

ページ番号の横にボタンを置き、設定は `localStorage` に保存します。音量はピーク 0.16 と控えめです。

## 確認したこと

- `npx next build` 成功
- dev サーバーで実際に再生して調整（砂 → 紙の質感まで詰めた）

🤖 Generated with [Claude Code](https://claude.com/claude-code)