### PR TITLE
feat(intro): 扉の歯車を増やして立体的なレリーフにする

### DIFF
--- a/components/GateIntro.js
+++ b/components/GateIntro.js
@@ -9,24 +9,139 @@ import styles from './GateIntro.module.css';
 const TOTAL_MS = 5250;
 const SKIP_MS = 320;
 
-/** 扉に埋め込まれた歯車。外側の span が始動の加速、内側の svg が定速回転を受け持つ */
-function DoorGear({ size, spin, delay = 0, reverse = false, tone = 'brass', style }) {
+/** 金属の陰影。歯車の塗りに使うグラデーションを一度だけ定義する */
+function MetalDefs() {
     return (
-        <span className={`${styles.gear} ${styles[tone]}`} style={{ width: size, height: size, ...style }}>
-            <svg
-                viewBox="0 0 100 100"
-                className={styles.gearSvg}
-                style={{
-                    animationDuration: `${spin}s`,
-                    animationDirection: reverse ? 'reverse' : 'normal',
-                    animationDelay: `${delay}s`,
-                }}
-            >
-                <path d={GEAR_PATH} fill="currentColor" />
+        <svg className={styles.defs} aria-hidden="true" focusable="false">
+            <defs>
+                <linearGradient id="gate-metal-steel" x1="0" y1="0" x2="0.85" y2="1">
+                    <stop offset="0%" stopColor="#e7edf1" />
+                    <stop offset="34%" stopColor="#aab4bc" />
+                    <stop offset="62%" stopColor="#69737b" />
+                    <stop offset="100%" stopColor="#39424a" />
+                </linearGradient>
+                <linearGradient id="gate-metal-brass" x1="0" y1="0" x2="0.85" y2="1">
+                    <stop offset="0%" stopColor="#f2dcae" />
+                    <stop offset="34%" stopColor="#cfa863" />
+                    <stop offset="62%" stopColor="#96702f" />
+                    <stop offset="100%" stopColor="#5a441d" />
+                </linearGradient>
+                <linearGradient id="gate-metal-copper" x1="0" y1="0" x2="0.85" y2="1">
+                    <stop offset="0%" stopColor="#f0c3a2" />
+                    <stop offset="34%" stopColor="#c07f52" />
+                    <stop offset="62%" stopColor="#8a5230" />
+                    <stop offset="100%" stopColor="#4d2c19" />
+                </linearGradient>
+                <linearGradient id="gate-metal-dark" x1="0" y1="0" x2="0.85" y2="1">
+                    <stop offset="0%" stopColor="#8e979e" />
+                    <stop offset="40%" stopColor="#5a636a" />
+                    <stop offset="100%" stopColor="#272e34" />
+                </linearGradient>
+            </defs>
+        </svg>
+    );
+}
+
+/**
+ * 扉に彫り込まれた歯車。
+ * span = 静止（影を落とす担当）／ svg = 始動の加速 ／ g = 定速回転
+ * 影を回さないために、回転する要素と影を落とす要素を分けている。
+ */
+function DoorGear({ size, spin, tone = 'steel', reverse = false, extra = false, style }) {
+    const cls = [styles.gear, styles[tone], extra ? styles.gearExtra : ''].filter(Boolean).join(' ');
+    return (
+        <span className={cls} style={{ width: size, height: size, ...style }}>
+            <svg viewBox="0 0 100 100" className={styles.gearSvg} aria-hidden="true">
+                <g
+                    className={styles.gearSpin}
+                    style={{
+                        animationDuration: `${spin}s`,
+                        animationDirection: reverse ? 'reverse' : 'normal',
+                    }}
+                >
+                    {/* 彫りの深さ：本体の下に暗い面をずらして敷く */}
+                    <path d={GEAR_PATH} fill="rgba(12, 16, 20, 0.55)" transform="translate(2.4 3)" />
+                    <path d={GEAR_PATH} fill={`url(#gate-metal-${tone})`} />
+                    {/* 上端の光。面取りに当たった反射 */}
+                    <path
+                        d={GEAR_PATH}
+                        fill="none"
+                        stroke="rgba(255, 255, 255, 0.42)"
+                        strokeWidth="0.9"
+                        transform="translate(-0.7 -0.9)"
+                    />
+                    <circle cx="51.7" cy="50" r="9" fill={`url(#gate-metal-dark)`} />
+                    <circle cx="51.7" cy="50" r="9" fill="none" stroke="rgba(0, 0, 0, 0.5)" strokeWidth="1.2" />
+                </g>
             </svg>
         </span>
     );
 }
+
+/** 打ち込まれたマイナスネジ */
+function Screw({ style, angle = 0, size = 15 }) {
+    return (
+        <span
+            className={styles.screw}
+            style={{ width: size, height: size, '--screw-angle': `${angle}deg`, ...style }}
+            aria-hidden="true"
+        />
+    );
+}
+
+// 左扉の歯車。噛み合って見えるよう、大小を寄せて重ねる
+const LEFT_GEARS = [
+    { size: 620, spin: 30, tone: 'steel', style: { top: '50%', right: '-310px', marginTop: '-310px' } },
+    { size: 300, spin: 20, tone: 'steel', reverse: true, style: { bottom: '1%', left: '3%' } },
+    { size: 214, spin: 12, tone: 'brass', style: { top: '19%', right: '13%' } },
+    { size: 152, spin: 8, tone: 'steel', reverse: true, style: { top: '33%', right: '1%' } },
+    { size: 124, spin: 6, tone: 'copper', style: { top: '7%', left: '25%' } },
+    { size: 186, spin: 14, tone: 'steel', style: { top: '1%', left: '1%' } },
+    { size: 96, spin: 5, tone: 'brass', reverse: true, style: { bottom: '25%', left: '29%' } },
+    { size: 134, spin: 9, tone: 'brass', style: { bottom: '11%', left: '33%' } },
+    { size: 78, spin: 4, tone: 'steel', style: { top: '25%', left: '13%' } },
+    { size: 164, spin: 11, tone: 'steel', reverse: true, style: { bottom: '29%', right: '23%' } },
+    { size: 110, spin: 7, tone: 'copper', style: { bottom: '4%', right: '6%' } },
+    { size: 66, spin: 3.5, tone: 'brass', reverse: true, style: { top: '45%', left: '1%' }, extra: true },
+    { size: 90, spin: 5, tone: 'steel', style: { top: '59%', left: '19%' }, extra: true },
+    { size: 206, spin: 16, tone: 'steel', style: { top: '51%', right: '5%' }, extra: true },
+    { size: 74, spin: 4, tone: 'copper', reverse: true, style: { bottom: '43%', left: '5%' }, extra: true },
+    { size: 58, spin: 3, tone: 'brass', style: { top: '15%', left: '39%' }, extra: true },
+];
+
+// 右扉。左とは配置も回転方向も変えて、対称に見えないようにする
+const RIGHT_GEARS = [
+    { size: 620, spin: 30, tone: 'steel', reverse: true, style: { top: '50%', left: '-310px', marginTop: '-310px' } },
+    { size: 286, spin: 19, tone: 'steel', style: { top: '2%', right: '4%' } },
+    { size: 228, spin: 13, tone: 'brass', reverse: true, style: { bottom: '14%', right: '11%' } },
+    { size: 146, spin: 8, tone: 'steel', style: { top: '41%', left: '2%' } },
+    { size: 118, spin: 6, tone: 'copper', reverse: true, style: { bottom: '4%', left: '22%' } },
+    { size: 178, spin: 14, tone: 'steel', reverse: true, style: { bottom: '1%', right: '34%' } },
+    { size: 98, spin: 5, tone: 'brass', style: { top: '27%', right: '30%' } },
+    { size: 138, spin: 9, tone: 'brass', reverse: true, style: { top: '12%', left: '14%' } },
+    { size: 80, spin: 4, tone: 'steel', reverse: true, style: { bottom: '31%', left: '9%' } },
+    { size: 158, spin: 11, tone: 'steel', style: { top: '58%', right: '18%' } },
+    { size: 106, spin: 7, tone: 'copper', reverse: true, style: { top: '3%', right: '38%' } },
+    { size: 70, spin: 3.5, tone: 'brass', style: { bottom: '46%', right: '2%' }, extra: true },
+    { size: 88, spin: 5, tone: 'steel', reverse: true, style: { bottom: '19%', left: '30%' }, extra: true },
+    { size: 198, spin: 16, tone: 'steel', reverse: true, style: { top: '33%', left: '18%' }, extra: true },
+    { size: 76, spin: 4, tone: 'copper', style: { top: '48%', right: '36%' }, extra: true },
+    { size: 60, spin: 3, tone: 'brass', reverse: true, style: { bottom: '38%', right: '26%' }, extra: true },
+];
+
+// ネジの位置（％）と首の向き
+const SCREWS = [
+    { top: '3%', left: '4%', angle: 24 },
+    { top: '3%', right: '5%', angle: -38 },
+    { bottom: '3%', left: '6%', angle: 62 },
+    { bottom: '3%', right: '4%', angle: 12 },
+    { top: '27%', left: '2%', angle: -14 },
+    { bottom: '27%', right: '2%', angle: 47 },
+    { top: '50%', left: '46%', angle: 33 },
+    { top: '13%', right: '30%', angle: -52 },
+    { bottom: '13%', left: '28%', angle: 8 },
+    { top: '68%', right: '44%', angle: -21 },
+];
 
 /** 鋼板・パイプ・補強梁・油圧ピストンといった扉の構造物 */
 function DoorFrame() {
@@ -48,6 +163,21 @@ function DoorFrame() {
                 <span className={styles.pistonRod} />
                 <span className={styles.pistonBody} />
             </span>
+        </>
+    );
+}
+
+/** 歯車を敷き詰めた面。ネジは歯車より手前に打つ */
+function GearPlate({ gears }) {
+    return (
+        <>
+            {gears.map((gear, i) => (
+                <DoorGear key={`g${i}`} {...gear} />
+            ))}
+            {SCREWS.map((screw, i) => {
+                const { angle, ...position } = screw;
+                return <Screw key={`s${i}`} angle={angle} style={position} />;
+            })}
         </>
     );
 }
@@ -96,25 +226,17 @@ export default function GateIntro() {
             role="presentation"
             aria-hidden="true"
         >
+            <MetalDefs />
+
             <div className={`${styles.panel} ${styles.panelLeft}`}>
                 <DoorFrame />
-                <DoorGear size={620} spin={26} tone="steel" style={{ top: '50%', right: '-310px', marginTop: '-310px' }} />
-                <DoorGear size={200} spin={9} reverse tone="brass" style={{ top: '26%', right: '18%' }} />
-                <DoorGear size={130} spin={6} tone="steel" style={{ top: '38%', right: '5%' }} />
-                <DoorGear size={280} spin={18} reverse tone="steel" style={{ bottom: '4%', left: '10%' }} />
-                <DoorGear size={110} spin={5} tone="neon" style={{ bottom: '24%', left: '32%' }} />
-                <DoorGear size={170} spin={11} reverse tone="copper" style={{ top: '2%', left: '20%' }} />
+                <GearPlate gears={LEFT_GEARS} />
                 <span className={styles.edge} />
             </div>
 
             <div className={`${styles.panel} ${styles.panelRight}`}>
                 <DoorFrame />
-                <DoorGear size={620} spin={26} reverse tone="steel" style={{ top: '50%', left: '-310px', marginTop: '-310px' }} />
-                <DoorGear size={200} spin={9} tone="brass" style={{ top: '30%', left: '16%' }} />
-                <DoorGear size={130} spin={6} reverse tone="steel" style={{ top: '42%', left: '4%' }} />
-                <DoorGear size={280} spin={18} tone="steel" style={{ bottom: '8%', right: '8%' }} />
-                <DoorGear size={110} spin={5} reverse tone="neon" style={{ bottom: '28%', right: '30%' }} />
-                <DoorGear size={170} spin={11} tone="copper" style={{ top: '1%', right: '22%' }} />
+                <GearPlate gears={RIGHT_GEARS} />
                 <span className={styles.edge} />
             </div>
 

--- a/components/GateIntro.module.css
+++ b/components/GateIntro.module.css
@@ -30,8 +30,10 @@
             rgba(0, 0, 0, 0.05) 2px 5px),
         linear-gradient(180deg, #838c93 0%, #6b747b 26%, #59626a 62%, #454d54 100%);
     box-shadow:
-        inset 0 0 140px rgba(20, 24, 28, 0.6),
-        inset 0 0 0 1px rgba(255, 255, 255, 0.14);
+        inset 0 0 160px rgba(12, 16, 20, 0.72),
+        inset 0 2px 0 rgba(255, 255, 255, 0.22),
+        inset 0 -3px 6px rgba(0, 0, 0, 0.55),
+        inset 0 0 0 1px rgba(255, 255, 255, 0.12);
     will-change: transform;
 }
 
@@ -120,9 +122,21 @@
     position: absolute;
     inset: 0;
     background:
-        radial-gradient(120% 90% at 50% 0%, rgba(255, 255, 255, 0.16), rgba(255, 255, 255, 0) 60%),
-        radial-gradient(100% 70% at 50% 100%, rgba(0, 0, 0, 0.35), rgba(0, 0, 0, 0) 70%);
+        radial-gradient(120% 90% at 50% 0%, rgba(255, 255, 255, 0.18), rgba(255, 255, 255, 0) 60%),
+        radial-gradient(100% 70% at 50% 100%, rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0) 70%);
     pointer-events: none;
+}
+
+/* 一段落ち込んだ内側の面（歯車はこの中に彫られている） */
+.grain::after {
+    content: '';
+    position: absolute;
+    inset: 22px;
+    border-radius: 3px;
+    box-shadow:
+        inset 0 3px 8px rgba(0, 0, 0, 0.6),
+        inset 0 -2px 0 rgba(255, 255, 255, 0.16),
+        0 1px 0 rgba(255, 255, 255, 0.14);
 }
 
 /* ===== 補強梁 ===== */
@@ -348,11 +362,23 @@
     bottom: 5%;
 }
 
-/* ===== 扉に埋まった歯車 ===== */
+/* ===== 扉に彫り込まれた歯車 ===== */
+/* グラデーション定義だけを持つ svg。描画しない */
+.defs {
+    position: absolute;
+    width: 0;
+    height: 0;
+    overflow: hidden;
+}
+
 .gear {
     position: absolute;
     display: block;
     pointer-events: none;
+    /* 影は span 側に置く。ここが回らないので、光の向きが固定される */
+    filter:
+        drop-shadow(3px 4px 3px rgba(8, 11, 14, 0.55))
+        drop-shadow(0 1px 0 rgba(255, 255, 255, 0.12));
     /* 始動：止まっていた歯車が加速して回り出す */
     animation: gate-boot 2.6s cubic-bezier(0.5, 0, 0.9, 0.6) both;
 }
@@ -361,6 +387,11 @@
     width: 100%;
     height: 100%;
     display: block;
+    overflow: visible;
+}
+
+.gearSpin {
+    transform-box: fill-box;
     transform-origin: center;
     animation-name: gate-spin;
     animation-timing-function: linear;
@@ -379,30 +410,53 @@
     }
 
     to {
-        transform: rotate(260deg);
+        transform: rotate(210deg);
     }
 }
 
+/* 金属の種類ごとの馴染み具合。塗り自体は svg のグラデーション */
+.steel {
+    opacity: 0.92;
+}
+
 .brass {
-    color: #d9a463;
-    opacity: 0.4;
+    opacity: 0.88;
 }
 
 .copper {
-    color: var(--c-gear-copper);
-    opacity: 0.34;
+    opacity: 0.85;
 }
 
-.steel {
-    color: #cdd5db;
-    opacity: 0.34;
-    filter: drop-shadow(0 3px 6px rgba(15, 18, 21, 0.45));
+/* ===== 打ち込まれたマイナスネジ ===== */
+.screw {
+    position: absolute;
+    border-radius: 50%;
+    background:
+        radial-gradient(circle at 33% 28%,
+            #dde3e8 0%,
+            #9ba4ab 40%,
+            #626b72 68%,
+            #333a40 100%);
+    box-shadow:
+        inset 0 1px 0 rgba(255, 255, 255, 0.55),
+        inset 0 -1px 2px rgba(0, 0, 0, 0.5),
+        0 2px 4px rgba(8, 11, 14, 0.6);
+    transform: rotate(var(--screw-angle, 0deg));
+    pointer-events: none;
+    z-index: 2;
 }
 
-.neon {
-    color: var(--c-accent-2);
-    opacity: 0.6;
-    filter: drop-shadow(0 0 12px rgba(69, 176, 186, 0.8));
+/* すり割り */
+.screw::after {
+    content: '';
+    position: absolute;
+    left: 16%;
+    right: 16%;
+    top: 44%;
+    height: 12%;
+    border-radius: 1px;
+    background: rgba(14, 18, 22, 0.8);
+    box-shadow: 0 1px 0 rgba(255, 255, 255, 0.35);
 }
 
 /* ===== 合わせ目 ===== */
@@ -615,7 +669,7 @@
 
     .panel,
     .gear,
-    .gearSvg,
+    .gearSpin,
     .pistonRod,
     .edge,
     .seam,
@@ -642,6 +696,19 @@
 
     .stripe {
         height: 20px;
+    }
+
+    /* 数を絞って描画の負荷を落とす */
+    .gearExtra {
+        display: none;
+    }
+
+    .gear {
+        filter: drop-shadow(2px 3px 2px rgba(8, 11, 14, 0.5));
+    }
+
+    .grain::after {
+        inset: 12px;
     }
 
     .pipe {


### PR DESCRIPTION
Closes #56

歯車が扉に印刷されているように見えて金属の重みが出ていなかったため、彫り込まれた立体として作り直しました。

## のっぺりして見えていた原因

1. 歯車が扉ごとに 6 枚しかなく、面がスカスカだった
2. 歯車が単色ベタ塗り＋低い不透明度で、陰影がまったくなかった
3. 扉の面が一枚板で、彫りの段差がなかった

## 変更

- **歯車を 6 枚 → 16 枚／扉**（合計 32 枚）。大小を重ねて密に配置し、合わせ目には直径 620px の大歯車を半分だけ置いています
- **単色ベタ塗りをやめ、svg のグラデーションで金属の面を作る**。真鍮・銅・鋼の 3 系統を定義し、中心にはハブのボルトを配置
- **彫りの深さ**は、本体の下に暗い面を 2.4/3px ずらして敷き、上端に光の線（白 0.42）を入れて表現
- **影の向きを固定**。影を落とす `span` と回転する `g` を分けたので、歯車が回っても影が一緒に回りません（回る影は正体不明のちらつきに見えます）
- **マイナスネジを 10 本／扉**打ち込み。すり割りの向きは 1 本ずつ変えています
- **扉の面に一段落ち込んだ彫り**をつくり、周囲に面取りの光を入れました

## 負荷

歯車 32 枚がそれぞれ回転＋影を持つので、狭い画面（640px 以下）では **5 枚／扉を間引き**、影も 1 層に落としています。

## 確認したこと

- `npx next build` 成功
- dev サーバーで歯車 32 枚・ネジ 20 本・グラデーション 4 種が描画されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)